### PR TITLE
Vale 3

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   qa:
-    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@vale3
+    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.64
     with:
       MD_CONFIG: .github/md_config.json
       DOC_SRC: content
       MD_LINT_CONFIG: .markdownlint.yaml
   build:
-    uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.62
+    uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.64
     with:
       DOCKER_FILE_PATH: Dockerfile
     secrets:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   qa:
-    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.62
+    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@vale3
     with:
       MD_CONFIG: .github/md_config.json
       DOC_SRC: content

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push:
-    uses: stakater/.github/.github/workflows/push_container.yaml@v0.0.62
+    uses: stakater/.github/.github/workflows/push_container.yaml@v0.0.64
     with:
       DOCKER_FILE_PATH: Dockerfile
       RELEASE_BRANCH: main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.62
+    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.64
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules
 
 # Build files
 site/
+styles/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vocabulary"]
-	path = vocabulary
-	url = git@github.com:stakater/vocabulary.git

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,8 @@
-StylesPath = "vocabulary/styles"
+StylesPath = styles
 MinAlertLevel = warning
 
-Vocab = "Stakater"
+Packages = https://github.com/stakater/vale-package/releases/download/v0.0.3/Stakater.zip
+Vocab = Stakater
 
 # Only check MarkDown files
 [*.md]

--- a/content/managed-service/offer.md
+++ b/content/managed-service/offer.md
@@ -39,4 +39,4 @@ Stakater platform supports three different ways to consume secrets from Vault: v
 
 ## Requirements
 
-Direct SSH access between client cloud and Stakater Vault cloud will be needed, preferably via site-to-site vpn.
+Direct SSH access between client cloud and Stakater Vault cloud will be needed, preferably via site-to-site VPN.

--- a/content/managed-service/offer.md
+++ b/content/managed-service/offer.md
@@ -39,4 +39,4 @@ Stakater platform supports three different ways to consume secrets from Vault: v
 
 ## Requirements
 
-Direct SSH access between client cloud and Stakater Vault cloud will be needed, preferably via site-to-site VPN.
+Direct SSH access between client cloud and Stakater Vault cloud will be needed, preferably via site-to-site vpn.

--- a/content/sealed-secrets.md
+++ b/content/sealed-secrets.md
@@ -48,8 +48,8 @@ Lets create a sample k8s secret that will be used for MySQL:
 
     where:
 
-    * `SECRET_FILE`: the name of the yaml file containing the k8s secret
-    * `SEALED_SECRET`: the name of the yaml file that will contain the sealed secret
+    * `SECRET_FILE`: the name of the YAML file containing the k8s secret
+    * `SEALED_SECRET`: the name of the YAML file that will contain the sealed secret
 
 1. Add and commit this sealed secret to source control
 

--- a/content/vault.md
+++ b/content/vault.md
@@ -76,7 +76,7 @@ To use the Vault CLI, a token is required. Users can get/renew/revoke a token fr
 
 1. Once a token is fetched, users can use the terminal provided by the UI, so there is no need to install the Vault CLI:
 
-    ![Vault-cli](./images/vault_cli.png)
+    ![Vault-CLI](./images/vault_cli.png)
 
 1. If using the Vault CLI, login with the token:
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "customManagers": [
+    {
+        "customType": "regex",
+        "fileMatch": [
+            "\\.yaml$"
+        ],
+        "matchStrings": [
+            "https:\/\/github.com\/(?<depName>.*)\/releases\/download\/(?<currentValue>.*)\/.*.tar.gz"
+        ],
+        "datasourceTemplate": "github-release-attachments"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     {
         "customType": "regex",
         "fileMatch": [
-            "\\.yaml$"
+            ".vale.ini"
         ],
         "matchStrings": [
             "https:\/\/github.com\/(?<depName>.*)\/releases\/download\/(?<currentValue>.*)\/.*.tar.gz"


### PR DESCRIPTION
Updates:
* Add `styles` to gitignore file so vale can be run locally without accidentally committing the vale package
* Remove vocabulary git submodule in favor of vale package
* Fix spelling mistakes since vale now fails the pipeline
* Add Renovate custom manager for GitHub release attachments so Vale package gets updated